### PR TITLE
`refgraph`: Add border to nodes that are both incoming and outgoing

### DIFF
--- a/refscan/templates/graph.template.html
+++ b/refscan/templates/graph.template.html
@@ -72,15 +72,15 @@
                     selector: "node.outgoer",
                     style: {
                         fontWeight: "bold",
-                        color: "#00ff00", // text color
-                        backgroundColor: "#00ff00",
+                        color: "#00FF00", // text color
+                        backgroundColor: "#00FF00",
                     }
                 },
                 {
                     selector: "edge.outgoer",
                     style: {
-                        lineColor: "#00ff00",
-                        targetArrowColor: "#00ff00",
+                        lineColor: "#00FF00",
+                        targetArrowColor: "#00FF00",
                         width: 3,
                     }
                 },
@@ -88,15 +88,15 @@
                     selector: "node.incomer",
                     style: {
                         fontWeight: "bold",
-                        color: "#ffA500", // text color
-                        backgroundColor: "#ffA500",
+                        color: "#FFA500", // text color
+                        backgroundColor: "#FFA500",
                     }
                 },
                 {
                     selector: "edge.incomer",
                     style: {
-                        lineColor: "#ffA500",
-                        targetArrowColor: "#ffA500",
+                        lineColor: "#FFA500",
+                        targetArrowColor: "#FFA500",
                         width: 3,
                     }
                 },
@@ -104,19 +104,19 @@
                     selector: "node.incomer.outgoer", // a node that is both an incomer and an outgoer
                     style: {
                         fontWeight: "bold",
-                        color: "#00ff00", // text color
-                        backgroundColor: "#00ff00",
+                        color: "#00FF00", // text color
+                        backgroundColor: "#00FF00",
                         borderWidth: 3,
                         borderStyle: "solid",
-                        borderColor: "#ffA500",
+                        borderColor: "#FFA500",
                     }
                 },
                 {
                     selector: "node.inFocus",
                     style: {
                         fontWeight: "bold",
-                        color: "#0000ff", // text color
-                        backgroundColor: "#0000ff"
+                        color: "#0000FF", // text color
+                        backgroundColor: "#0000FF"
                     }
                 }
             ],

--- a/refscan/templates/graph.template.html
+++ b/refscan/templates/graph.template.html
@@ -101,6 +101,17 @@
                     }
                 },
                 {
+                    selector: "node.incomer.outgoer", // a node that is both an incomer and an outgoer
+                    style: {
+                        fontWeight: "bold",
+                        color: "#00ff00", // text color
+                        backgroundColor: "#00ff00",
+                        borderWidth: 3,
+                        borderStyle: "solid",
+                        borderColor: "#ffA500",
+                    }
+                },
+                {
                     selector: "node.inFocus",
                     style: {
                         fontWeight: "bold",


### PR DESCRIPTION
Summary of changes:
- `refgraph`: Add border to nodes that are both incoming and outgoing
- `refgraph`: Standardize letter casing within hex color code strings