### PR TITLE
`refgraph`: Read schema directly instead of requiring TSV file generated by `refscan`

### DIFF
--- a/refscan/lib/Reference.py
+++ b/refscan/lib/Reference.py
@@ -16,3 +16,22 @@ class Reference:
     source_field_name: str = field()  # e.g. "part_of"
     target_collection_name: str = field()  # e.g. "study_set" (reminder: a study can be part of another study)
     target_class_name: str = field()  # e.g. "Study"
+
+    def __eq__(self, other):
+        r"""
+        Determines whether an instance of this class is equal to the specified "other" value.
+
+        Note: This method dictates what will happen under the hood when the `==` operator is used.
+              Reference: https://docs.python.org/3/reference/datamodel.html#object.__eq__
+        """
+
+        if not isinstance(other, Reference):
+            return False
+        else:
+            return (
+                self.source_collection_name == other.source_collection_name
+                and self.source_class_name == other.source_class_name
+                and self.source_field_name == other.source_field_name
+                and self.target_collection_name == other.target_collection_name
+                and self.target_class_name == other.target_class_name
+            )

--- a/refscan/refgraph.py
+++ b/refscan/refgraph.py
@@ -186,8 +186,8 @@ def graph(
     graph_data_json_bytes = graph_data_json_str.encode("utf-8")
     graph_data_json_base64 = base64.b64encode(graph_data_json_bytes)
     graph_data_json_base64_str = graph_data_json_base64.decode("utf-8")
-    placeholder = "{{ graph_data_json_base64 }}"
-    html_result = html_template.replace(placeholder, graph_data_json_base64_str)
+    html_result = html_template.replace("{{ schema_version }}", schema_view.schema.version)
+    html_result = html_result.replace("{{ graph_data_json_base64 }}", graph_data_json_base64_str)
 
     if verbose:
         console.print(html_result)

--- a/refscan/refgraph.py
+++ b/refscan/refgraph.py
@@ -16,6 +16,7 @@ from refscan.lib.helpers import (
     get_names_of_classes_eligible_for_collection,
     identify_references,
 )
+from refscan.refscan import display_app_version_and_exit
 
 app = typer.Typer(
     help="Generates an interactive graph (network diagram) of the references described by a schema.",
@@ -85,6 +86,15 @@ def graph(
             help="Show verbose output.",
         ),
     ] = False,
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            callback=display_app_version_and_exit,
+            is_eager=True,  # tells Typer to process this option first
+            help="Show version number and exit.",
+        ),
+    ] = None,
 ):
     r"""
     Generates an interactive graph (network diagram) of the references described by a schema.

--- a/refscan/templates/graph.template.html
+++ b/refscan/templates/graph.template.html
@@ -29,6 +29,9 @@
 
 <script>
     (function () {
+        // Note: A Python script will replace the `{{ ... }}` placeholder.
+        console.log("Schema version: {{ schema_version }}");
+
         // Extract the graph data, base64decode it, and parse it as JSON.
         // Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset
         let graphData = []

--- a/tests/schemas/database_with_references.yaml
+++ b/tests/schemas/database_with_references.yaml
@@ -1,0 +1,32 @@
+id: my-schema
+name: MySchema
+
+classes:
+  Database:
+    slots:
+      - company_set
+      - employee_set
+  Company:
+    slots:
+      - employs
+  Employee:
+    slots:
+      - works_for
+      - managed_by
+
+slots:
+  company_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Company
+  employee_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Employee
+  works_for:
+    range: Company
+  employs:
+    range: Employee
+  managed_by:
+    range: Employee
+

--- a/tests/test_Reference.py
+++ b/tests/test_Reference.py
@@ -1,0 +1,49 @@
+from refscan.lib.Reference import Reference
+
+
+def test_eq():
+    ref_a = Reference(
+        source_collection_name="foo_set",
+        source_class_name="Foo",
+        source_field_name="owns",
+        target_collection_name="bar_set",
+        target_class_name="Bar",
+    )
+    ref_b = Reference(
+        source_collection_name="foo_set",
+        source_class_name="Foo",
+        source_field_name="owns",
+        target_collection_name="bar_set",
+        target_class_name="Baz",  # not "Bar"
+    )
+    ref_c = Reference(
+        source_collection_name="foo_set",
+        source_class_name="Foo",
+        source_field_name="owns",
+        target_collection_name="bar_set",
+        target_class_name="Bar",
+    )
+
+    # Focus on `==`.
+    assert ref_a == ref_a
+    assert ref_a != ref_b
+    assert ref_a == ref_c
+
+    assert ref_b != ref_a
+    assert ref_b == ref_b
+    assert ref_b != ref_c
+
+    assert ref_c == ref_a
+    assert ref_c != ref_b
+    assert ref_c == ref_c
+
+    # Focus on `in`.
+    assert ref_a in [ref_a, ref_b, ref_c]
+    assert ref_b in [ref_a, ref_b, ref_c]
+    assert ref_c in [ref_a, ref_b, ref_c]
+
+    assert ref_a not in [ref_b]
+
+    # Focus on `is`.
+    assert ref_a is ref_a
+    assert ref_a is not ref_c  # equal, but not identical


### PR DESCRIPTION
- Made it so refgraph reads a schema directly, instead of reading a `references.tsv` file
- Moved some common code to a helper function and added tests targeting that code
- Updated the web page generated by refgraph so it prints the schema version to the JS console