### PR TITLE
Lower Python version requirement from `3.10` to `3.9`

### DIFF
--- a/.github/workflows/build-and-publish-package-to-pypi.yml
+++ b/.github/workflows/build-and-publish-package-to-pypi.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           # Specify a Python version that satisfies the `tool.poetry.dependencies.python`
           # version requirement specified in `pyproject.toml`.
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Install Poetry  # Docs: https://github.com/snok/install-poetry
         uses: snok/install-poetry@v1
       - name: Install dependencies  # Docs: https://python-poetry.org/docs/cli/#install

--- a/poetry.lock
+++ b/poetry.lock
@@ -1399,5 +1399,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "f4f04d72f2f2c120040f2bd4e0c7272a1c6d7c0db6851dbe0334d8f65986699a"
+python-versions = "^3.9"
+content-hash = "1ab02359f4d439a4fa75e64efdb8dd83cf37046045de902eb7989ec9511ac491"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/microbiomedata/refscan"
 keywords = ["mongodb", "mongo", "relationships", "reference", "database", "data", "referential integrity", "scan"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 # We use `linkml-runtime` to facilitate using `nmdc-schema`.
 # Docs: https://linkml.io/linkml/developers/schemaview.html#linkml_runtime.utils.schemaview.SchemaView
 linkml-runtime = "^1.7.5"

--- a/refscan/refgraph.py
+++ b/refscan/refgraph.py
@@ -41,7 +41,7 @@ def load_template(resource_path: str) -> str:
           that the path is accurate both when this script is run in a development
           environment and when this script is run when installed from PyPI,
           instead of it only being accurate in the former case.
-          Reference: https://docs.python.org/3.10/library/importlib.html
+          Reference: https://docs.python.org/3.9/library/importlib.html#importlib.resources.files
     """
     package_name = "refscan"
     return resources.files(package_name).joinpath(resource_path).read_text(encoding="utf-8")


### PR DESCRIPTION
This is in an attempt to allow older Python projects (ones whose Python version requirements say Python can be as low as `3.9`) to specify it as a dependency without raising their own Python version requirements.