### PR TITLE
Include source document's schema class name in violation report

### DIFF
--- a/refscan/lib/Violation.py
+++ b/refscan/lib/Violation.py
@@ -9,6 +9,7 @@ class Violation:
     """
 
     source_collection_name: str = field()
+    source_class_name: str = field()
     source_field_name: str = field()
     source_document_object_id: str = field()
     source_document_id: str = field()

--- a/refscan/refscan.py
+++ b/refscan/refscan.py
@@ -334,6 +334,7 @@ def scan(
 
                                 violation = Violation(
                                     source_collection_name=source_collection_name,
+                                    source_class_name=source_class_name,
                                     source_field_name=field_name,
                                     source_document_object_id=source_document_object_id,
                                     source_document_id=source_document_id,


### PR DESCRIPTION
In this branch, I update refscan so that it includes the name of the schema class of which the source document describes an instance, in the violation report. That will make it easier for readers of violation reports to interpret the violation information (since a given Mongo collection can contain documents of more than one class).