### PR TITLE
Update test coverage of cli using CliRunner

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+from refscan.cli.cli import app
+from typer.testing import CliRunner
+from pathlib import Path
+
+
+def test_graph_command_no_args():
+    """Test the `graph` command with no arguments."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code != 0, "The command should fail when no arguments are provided."
+    assert "Usage:" in result.output, "Help message should be displayed when no arguments are provided."
+
+def test_graph_command_with_valid_schema():
+    """Test the `graph` command with a valid schema file."""
+    runner = CliRunner()
+    schema_path = Path("tests/schemas/database_with_references.yaml")
+    output_path = Path("/tmp/graph.html")
+
+    result = runner.invoke(app, [
+        "graph",
+        "--schema",
+        str(schema_path),
+        "--graph",
+        str(output_path),
+        "--subject",
+        "collection",
+        "--verbose",
+    ])
+
+    assert result.exit_code == 0, f"Unexpected exit code: {result.exit_code}"
+    assert "Graph generated at:" in result.output, "Graph generation message not displayed."
+    assert output_path.exists(), "The output graph file should be created."
+
+
+def test_graph_command_with_custom_output_path():
+    """Test the `graph` command with a custom output file path."""
+    runner = CliRunner()
+    schema_path = Path("tests/schemas/database_with_references.yaml")
+    custom_output_path = Path("/tmp/custom_graph.html")
+
+    result = runner.invoke(app, [
+        "graph",
+        "--schema",
+        str(schema_path),
+        "--graph",
+        str(custom_output_path),
+    ])
+
+    assert result.exit_code == 0, f"Unexpected exit code: {result.exit_code}"
+    assert "Graph generated at:" in result.output, "Graph generation message not displayed."
+    assert custom_output_path.exists(), "The custom output graph file should be created."
+
+def test_graph_command_help():
+    """Test the `graph` command with the --help flag."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["graph", "--help"])
+
+    assert result.exit_code == 0, f"Unexpected exit code: {result.exit_code}"
+    assert "Usage:" in result.output, "Help message should be displayed."
+    assert "--schema" in result.output, "Schema option should be described in the help message."
+    assert "--graph" in result.output, "Graph option should be described in the help message."
+    assert "--subject" in result.output, "Subject option should be described in the help message."
+    assert "--verbose" in result.output, "Verbose option should be described in the help message."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_graph_command_with_valid_schema():
     """Test the `graph` command with a valid schema file."""
     runner = CliRunner()
     schema_path = Path("tests/schemas/database_with_references.yaml")
-    output_path = Path("/tmp/graph.html")
+    output_path = Path("graph.html")
 
     result = runner.invoke(app, [
         "graph",
@@ -36,7 +36,7 @@ def test_graph_command_with_custom_output_path():
     """Test the `graph` command with a custom output file path."""
     runner = CliRunner()
     schema_path = Path("tests/schemas/database_with_references.yaml")
-    custom_output_path = Path("/tmp/custom_graph.html")
+    custom_output_path = Path("custom_graph.html")
 
     result = runner.invoke(app, [
         "graph",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,22 +10,26 @@ def test_graph_command_no_args():
     assert result.exit_code != 0, "The command should fail when no arguments are provided."
     assert "Usage:" in result.output, "Help message should be displayed when no arguments are provided."
 
+
 def test_graph_command_with_valid_schema():
     """Test the `graph` command with a valid schema file."""
     runner = CliRunner()
     schema_path = Path("tests/schemas/database_with_references.yaml")
     output_path = Path("graph.html")
 
-    result = runner.invoke(app, [
-        "graph",
-        "--schema",
-        str(schema_path),
-        "--graph",
-        str(output_path),
-        "--subject",
-        "collection",
-        "--verbose",
-    ])
+    result = runner.invoke(
+        app,
+        [
+            "graph",
+            "--schema",
+            str(schema_path),
+            "--graph",
+            str(output_path),
+            "--subject",
+            "collection",
+            "--verbose",
+        ],
+    )
 
     assert result.exit_code == 0, f"Unexpected exit code: {result.exit_code}"
     assert "Graph generated at:" in result.output, "Graph generation message not displayed."
@@ -38,17 +42,21 @@ def test_graph_command_with_custom_output_path():
     schema_path = Path("tests/schemas/database_with_references.yaml")
     custom_output_path = Path("custom_graph.html")
 
-    result = runner.invoke(app, [
-        "graph",
-        "--schema",
-        str(schema_path),
-        "--graph",
-        str(custom_output_path),
-    ])
+    result = runner.invoke(
+        app,
+        [
+            "graph",
+            "--schema",
+            str(schema_path),
+            "--graph",
+            str(custom_output_path),
+        ],
+    )
 
     assert result.exit_code == 0, f"Unexpected exit code: {result.exit_code}"
     assert "Graph generated at:" in result.output, "Graph generation message not displayed."
     assert custom_output_path.exists(), "The custom output graph file should be created."
+
 
 def test_graph_command_help():
     """Test the `graph` command with the --help flag."""


### PR DESCRIPTION
Apologies for the drive-by-pull-request!  I was working on upgrading refscan in nmdc-schema and while debugging over there, I ended up adding some tests over here to help me understand how to execute the cli in a controlled environment.

It is not urgent to pull in, just bumps the coverage a bit for grapher.py and graph.py
