### PR TITLE
Add support for `Database` slots that define their range via `any_of`

### DIFF
--- a/refscan/lib/helpers.py
+++ b/refscan/lib/helpers.py
@@ -59,8 +59,9 @@ def get_names_of_classes_eligible_for_collection(schema_view: SchemaView, collec
     according to the specified `SchemaView`.
     """
     slot_definition = schema_view.induced_slot(collection_name, DATABASE_CLASS_NAME)
-    name_of_eligible_class = slot_definition.range
-    names_of_eligible_classes = schema_view.class_descendants(name_of_eligible_class)  # includes own class name
+    names_of_eligible_classes = get_names_of_classes_in_effective_range_of_slot(
+        schema_view=schema_view, slot_definition=slot_definition
+    )
     return names_of_eligible_classes
 
 

--- a/tests/schemas/database_class_with_any_of.yaml
+++ b/tests/schemas/database_class_with_any_of.yaml
@@ -1,0 +1,28 @@
+id: my-schema
+name: MySchema
+
+classes:
+  Food: { }
+  Fruit:
+    is_a: Food
+  Veggie:
+    is_a: Food
+  Carrot:
+    is_a: Veggie
+  Database:
+    slots:
+      - flexible_set
+      - rigid_set
+
+slots:
+  flexible_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Food
+  rigid_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Food
+    any_of:
+      - range: Fruit
+      - range: Carrot

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,6 +49,22 @@ def test_get_names_of_classes_eligible_for_collection():
     assert "Biosample" in collection_names
     assert "MaterialEntity" in collection_names
 
+    # Ensure the function correctly handles `Database` slots that use `any_of` to define their ranges.
+    schema_view = linkml_runtime.SchemaView(schema="tests/schemas/database_class_with_any_of.yaml")
+    assert isinstance(schema_view, linkml_runtime.SchemaView)
+
+    collection_names = get_names_of_classes_eligible_for_collection(schema_view, "flexible_set")
+    assert len(collection_names) == 4
+    assert "Food" in collection_names
+    assert "Fruit" in collection_names
+    assert "Veggie" in collection_names
+    assert "Carrot" in collection_names
+
+    collection_names = get_names_of_classes_eligible_for_collection(schema_view, "rigid_set")
+    assert len(collection_names) == 2
+    assert "Fruit" in collection_names
+    assert "Carrot" in collection_names
+
 
 def test_get_names_of_classes_in_effective_range_of_slot():
     schema_view = linkml_runtime.SchemaView(schema="tests/schemas/schema_with_any_of.yaml")


### PR DESCRIPTION
Previously, the `get_names_of_classes_eligible_for_collection` function was only looking at the `Database` slot's `range` attribute—regardless of whether the slot had an `any_of` attribute also defined. On this branch, I made it so the function uses `any_of` if it is present (i.e. the same way other parts of Refscan do).