### PR TITLE
Add abstract class visibility toggler button to diagram web page

### DIFF
--- a/refscan/grapher.py
+++ b/refscan/grapher.py
@@ -48,6 +48,18 @@ def encode_json_value_as_base64_str(json_value: Union[dict, list]) -> str:
     return encoded_bytes_as_string
 
 
+def is_class_abstract(class_name: str, schema_view: linkml_runtime.SchemaView) -> bool:
+    r"""
+    Returns whether the specified schema class is abstract.
+
+    Note: The `abstract` property can contain `True`, `False`, or `None`.
+
+    Reference: https://linkml.io/linkml/schemas/inheritance.html#abstract-classes-and-slots
+    """
+
+    return schema_view.get_class(class_name).abstract is True
+
+
 def graph(
     schema_view: linkml_runtime.SchemaView,
     subject: Subject,
@@ -106,12 +118,17 @@ def graph(
         source_name = r.source_collection_name if subject == Subject.collection else r.source_class_name
         target_name = r.target_collection_name if subject == Subject.collection else r.target_class_name
 
+        # If the subject of the graph is "class", determine whether the source class is abstract. Same for the target class.
+        # Note: This will allow us to display abstract classes differently from concrete classes in the diagram.
+        is_source_abstract = is_class_abstract(source_name, schema_view) if subject == Subject.class_ else None
+        is_target_abstract = is_class_abstract(target_name, schema_view) if subject == Subject.class_ else None
+
         # Append a node for the source subject if we haven't already done so. Same for the target subject.
         node_ids = [n["data"]["id"] for n in nodes]
         if source_name not in node_ids:
-            nodes.append(dict(data=dict(id=source_name)))
+            nodes.append(dict(data=dict(id=source_name, is_abstract=is_source_abstract)))
         if target_name not in node_ids:
-            nodes.append(dict(data=dict(id=target_name)))
+            nodes.append(dict(data=dict(id=target_name, is_abstract=is_target_abstract)))
 
         # Append an edge for this source subject-to-target subject relationship if we haven't already done so.
         edge_id = f"{source_name}__to__{target_name}"

--- a/refscan/templates/graph.template.html
+++ b/refscan/templates/graph.template.html
@@ -174,7 +174,19 @@
                         color: "#0000FF", // text color
                         backgroundColor: "#0000FF"
                     }
-                }
+                },
+                {
+                    selector: "node.isAbstract",
+                    style: {
+                        opacity: 0.5,
+                    }
+                },
+                {
+                    selector: "edge.isAbstract",
+                    style: {
+                        opacity: 0.67,
+                    }
+                },
             ],
         });
 
@@ -214,6 +226,35 @@
                 .removeClass("incomer")
                 .removeClass("inFocus");
         });
+
+        // Get a collection of all nodes that represent abstract things.
+        // Note: For convenience, we refer to them as "abstract nodes."
+        // Reference: https://js.cytoscape.org/#eles.filter
+        const abstractNodes = cy.filter(function(el, idx, allEls) {
+            return el.isNode() && el.data("is_abstract");
+        });
+
+        // Add "stylesheet" classes that we can use to style the abstract nodes and the edges connected to them.
+        abstractNodes.addClass("isAbstract");
+        abstractNodes.connectedEdges().addClass("isAbstract");
+
+        // Set up the button that can be used to show/hide the abstract nodes.
+        // TODO: Consider updating refscan to pass a subject name to this web page, to use in UI messages (e.g. "...abstract classes").
+        let removedEls = [];
+        const togglerEl = document.createElement("button");
+        togglerEl.textContent = "Toggle abstract nodes";
+        togglerEl.disabled = abstractNodes.length === 0; // TODO: Consider hiding the button completely in this case
+        togglerEl.title = "Toggle the visibility of nodes that represent abstract things.";
+        togglerEl.addEventListener("click", () => {
+            if (removedEls.length > 0) {
+                removedEls.restore();
+                removedEls = [];
+            } else {
+                removedEls = cy.remove(abstractNodes);
+                console.debug(`Removing ${removedEls.length} nodes representing abstract things:`, removedEls);
+            }
+        });
+        metadataContainerEl.appendChild(togglerEl);
     })();
 </script>
 </body>

--- a/tests/test_grapher.py
+++ b/tests/test_grapher.py
@@ -1,7 +1,18 @@
-from refscan.grapher import load_template
+import linkml_runtime
+
+from refscan.grapher import load_template, is_class_abstract
 
 
 def test_load_template():
     template = load_template(r"templates/graph.template.html")
     assert isinstance(template, str)
     assert len(template) > 0
+
+
+def test_is_class_abstract():
+    schema_view = linkml_runtime.SchemaView(schema="tests/schemas/schema_with_abstract_class.yaml")
+    assert isinstance(schema_view, linkml_runtime.SchemaView)
+
+    assert is_class_abstract("NamedThing", schema_view) is True
+    assert is_class_abstract("Car", schema_view) is False
+    assert is_class_abstract("Boat", schema_view) is False


### PR DESCRIPTION
Here's what the web page looks like with 4 abstract classes present. Their nodes have an opacity of 50% and their connected edges have an opacity of 67%. Clicking the button hides those nodes and edges. Clicking the button again makes those nodes and edges visible again.

![image](https://github.com/user-attachments/assets/a3dd5ccb-eeb7-487e-8d74-b1f708591b6c)

TODO:
- Refine the JavaScript
- Refine the UI
- Make sure the interfaces/abstractions in this code are clean/clear