### PR TITLE
Derive values instead of requiring caller to provide them (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ While editing the tool's source code, you can run the tool as you normally would
 poetry run refscan --help
 ```
 
+### Check types
+
+We use [mypy](https://mypy.readthedocs.io/en/stable/) as the static type checker for `refscan`.
+
+You can perform static type checking by running the following command from the root directory of the repository:
+
+```shell
+poetry run mypy
+```
+
 ### Run tests
 
 We use [pytest](https://docs.pytest.org/en/8.2.x/) as the testing framework for `refscan`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -573,6 +573,60 @@ pyexecjs = ["pyexecjs"]
 pymongo = ["pymongo"]
 
 [[package]]
+name = "mypy"
+version = "1.16.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "mypy-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7909541fef256527e5ee9c0a7e2aeed78b6cda72ba44298d1334fe7881b05c5c"},
+    {file = "mypy-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e71d6f0090c2256c713ed3d52711d01859c82608b5d68d4fa01a3fe30df95571"},
+    {file = "mypy-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:936ccfdd749af4766be824268bfe22d1db9eb2f34a3ea1d00ffbe5b5265f5491"},
+    {file = "mypy-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4086883a73166631307fdd330c4a9080ce24913d4f4c5ec596c601b3a4bdd777"},
+    {file = "mypy-1.16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:feec38097f71797da0231997e0de3a58108c51845399669ebc532c815f93866b"},
+    {file = "mypy-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:09a8da6a0ee9a9770b8ff61b39c0bb07971cda90e7297f4213741b48a0cc8d93"},
+    {file = "mypy-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9f826aaa7ff8443bac6a494cf743f591488ea940dd360e7dd330e30dd772a5ab"},
+    {file = "mypy-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82d056e6faa508501af333a6af192c700b33e15865bda49611e3d7d8358ebea2"},
+    {file = "mypy-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:089bedc02307c2548eb51f426e085546db1fa7dd87fbb7c9fa561575cf6eb1ff"},
+    {file = "mypy-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a2322896003ba66bbd1318c10d3afdfe24e78ef12ea10e2acd985e9d684a666"},
+    {file = "mypy-1.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:021a68568082c5b36e977d54e8f1de978baf401a33884ffcea09bd8e88a98f4c"},
+    {file = "mypy-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:54066fed302d83bf5128632d05b4ec68412e1f03ef2c300434057d66866cea4b"},
+    {file = "mypy-1.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5436d11e89a3ad16ce8afe752f0f373ae9620841c50883dc96f8b8805620b13"},
+    {file = "mypy-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f2622af30bf01d8fc36466231bdd203d120d7a599a6d88fb22bdcb9dbff84090"},
+    {file = "mypy-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d045d33c284e10a038f5e29faca055b90eee87da3fc63b8889085744ebabb5a1"},
+    {file = "mypy-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b4968f14f44c62e2ec4a038c8797a87315be8df7740dc3ee8d3bfe1c6bf5dba8"},
+    {file = "mypy-1.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eb14a4a871bb8efb1e4a50360d4e3c8d6c601e7a31028a2c79f9bb659b63d730"},
+    {file = "mypy-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:bd4e1ebe126152a7bbaa4daedd781c90c8f9643c79b9748caa270ad542f12bec"},
+    {file = "mypy-1.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b"},
+    {file = "mypy-1.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0"},
+    {file = "mypy-1.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b"},
+    {file = "mypy-1.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d"},
+    {file = "mypy-1.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52"},
+    {file = "mypy-1.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb"},
+    {file = "mypy-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f56236114c425620875c7cf71700e3d60004858da856c6fc78998ffe767b73d3"},
+    {file = "mypy-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:15486beea80be24ff067d7d0ede673b001d0d684d0095803b3e6e17a886a2a92"},
+    {file = "mypy-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2ed0e0847a80655afa2c121835b848ed101cc7b8d8d6ecc5205aedc732b1436"},
+    {file = "mypy-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb5fbc8063cb4fde7787e4c0406aa63094a34a2daf4673f359a1fb64050e9cb2"},
+    {file = "mypy-1.16.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a5fcfdb7318c6a8dd127b14b1052743b83e97a970f0edb6c913211507a255e20"},
+    {file = "mypy-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:2e7e0ad35275e02797323a5aa1be0b14a4d03ffdb2e5f2b0489fa07b89c67b21"},
+    {file = "mypy-1.16.0-py3-none-any.whl", hash = "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031"},
+    {file = "mypy-1.16.0.tar.gz", hash = "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab"},
+]
+
+[package.dependencies]
+mypy_extensions = ">=1.0.0"
+pathspec = ">=0.9.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing_extensions = ">=4.6.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+faster-cache = ["orjson"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1510,4 +1564,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "bbd908ad411ed5c20645f06e444f5658f89f1ca3c387617b2b10ddcfee3dad8a"
+content-hash = "f2c26f1a47a643be5836f015f38a5ae00476f5bf8135e7b5dba1732d26a388ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ pytest-cov = "^5.0.0"
 # We use `mongomock` to test MongoDB interaction without involving a real MongoDB instance.
 # Docs: https://github.com/mongomock/mongomock
 mongomock = "^4.3.0"
+# We use `mypy` to perform static type checking.
+# Usage: $ poetry run mypy
+# Docs: https://mypy.readthedocs.io/en/stable/
+mypy = "^1.16.0"
 
 [tool.poetry.scripts]
 # Reference: https://python-poetry.org/docs/pyproject#scripts
@@ -60,6 +64,25 @@ addopts = "--doctest-modules --cov=refscan"
 # Make it so that, when someone runs `$ poetry run black`, these default CLI options are used.
 # Reference: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format
 line-length = 120
+
+[tool.mypy]
+# Make it so, when someone runs `$ poetry run mypy`, these default CLI options are used.
+# Reference: https://mypy.readthedocs.io/en/stable/config_file.html
+files = "."
+
+[[tool.mypy.overrides]]
+# Silence the following error:
+# > Skipping analyzing "linkml_runtime": module is installed, but missing library stubs or py.typed marker  [import-untyped] 
+#
+# Note: We first tried using the following, but it seemed to have no effect on the behavior of mypy when run via `$ poetry run mypy`.
+#       ```
+#       [mypy-linkml_runtime]
+#       ignore_missing_imports = true
+#       ```
+#       So, we—instead—used the syntax shown on: https://stackoverflow.com/a/74198016
+#
+module = "linkml_runtime"
+ignore_missing_imports = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/refscan/__init__.py
+++ b/refscan/__init__.py
@@ -12,7 +12,7 @@ def get_package_metadata(key: str) -> str:
     metadata_value = ""
     try:
         package_metadata = metadata("refscan")
-        metadata_value = package_metadata.get(key)
+        metadata_value = package_metadata.get(key, "")
     except PackageNotFoundError:
         pass
     return metadata_value

--- a/refscan/cli/scan.py
+++ b/refscan/cli/scan.py
@@ -172,7 +172,6 @@ def scan(
         db=db,
         schema_view=schema_view,
         references=references,
-        collection_names=collection_names,
         names_of_source_collections_to_skip=names_of_source_collections_to_skip,
         user_wants_to_locate_misplaced_documents=user_wants_to_locate_misplaced_documents,
         verbose=verbose,

--- a/refscan/grapher.py
+++ b/refscan/grapher.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union
+from typing import Union, List, Dict, Any
 import json
 import base64
 from importlib import resources
@@ -14,6 +14,11 @@ from refscan.lib.helpers import (
     get_collection_names_from_schema,
     identify_references,
 )
+
+# Define some type aliases that we can reference later, to simplify the latter type hints.
+# TODO: Update these type hints to not use `Any`.
+NodeType = Dict[str, Dict[str, Any]]
+EdgeType = Dict[str, Dict[str, Any]]
 
 
 class Subject(str, Enum):
@@ -105,8 +110,8 @@ def graph(
     #
     # Reference: https://js.cytoscape.org/#notation/elements-json
     #
-    nodes = []
-    edges = []
+    nodes: List[NodeType] = []
+    edges: List[EdgeType] = []
     for r in references:
         # Get the source and target names depending upon the subject of the graph.
         source_name = r.source_collection_name if subject == Subject.collection else r.source_class_name

--- a/refscan/lib/Finder.py
+++ b/refscan/lib/Finder.py
@@ -24,8 +24,8 @@ class Finder:
         #       from source documents that we process _temporally close_ to one another, likely point to target
         #       documents residing _in the same collections_ as one another.
         #
-        self.cached_collection_names_where_recently_found = []
-        self.cache_size = 2  # we'll cache up to 2 collection names
+        self.cached_collection_names_where_recently_found: List[str] = []
+        self.cache_size: int = 2  # we'll cache up to 2 collection names
 
         # Initialize our cache of document `id` presences/absences by collection.
         #

--- a/refscan/lib/helpers.py
+++ b/refscan/lib/helpers.py
@@ -18,6 +18,8 @@ def connect_to_database(mongo_uri: str, database_name: str, verbose: bool = True
     mongo_client: MongoClient = MongoClient(host=mongo_uri, directConnection=True)
 
     with timeout(5):  # if any message exchange takes > 5 seconds, this will raise an exception
+        if mongo_client.address is None:
+            raise ValueError("Failed to determine MongoDB server hostname or port number.")
         (host, port_number) = mongo_client.address
 
         if verbose:

--- a/refscan/scanner.py
+++ b/refscan/scanner.py
@@ -214,7 +214,6 @@ def scan(
     db: Database,
     schema_view: SchemaView,
     references: ReferenceList,
-    collection_names: List[str],
     names_of_source_collections_to_skip: List[str],
     user_wants_to_locate_misplaced_documents: bool = False,
     console: Console = default_console,
@@ -228,7 +227,6 @@ def scan(
     :param schema_view: A SchemaView bound to the schema with which that database complies
                         (except that it may not be compliant in terms of referential integrity)
     :param references: A `ReferenceList` derived from the schema
-    :param collection_names: List of collection names that are described by the schema
     :param names_of_source_collections_to_skip: List of source collections to skip
     :param user_wants_to_locate_misplaced_documents: Whether the user wants the function to proceed to search illegal
                                                      collections after failing to find the referenced document among
@@ -236,9 +234,6 @@ def scan(
     :param console: A `Console` to which the function can print messages
     :param verbose: Whether you want the function to print a higher-than-normal amount of information to the console
     """
-
-    # Get a dictionary that maps source class names to the names of their fields that can contain references.
-    reference_field_names_by_source_class_name = references.get_reference_field_names_by_source_class_name()
 
     # Initialize a progress bar.
     custom_progress = init_progress_bar()
@@ -319,10 +314,8 @@ def scan(
                 violations = scan_outgoing_references(
                     document=document,
                     schema_view=schema_view,
-                    reference_field_names_by_source_class_name=reference_field_names_by_source_class_name,
                     references=references,
                     finder=finder,
-                    collection_names=collection_names,
                     source_collection_name=source_collection_name,
                     user_wants_to_locate_misplaced_documents=user_wants_to_locate_misplaced_documents,
                 )

--- a/refscan/scanner.py
+++ b/refscan/scanner.py
@@ -141,7 +141,7 @@ def scan_outgoing_references(
 
     # Get the document's `id` so that we can include it in this script's output.
     source_document_object_id = document["_id"]
-    source_document_id = document["id"] if "id" in document else None
+    source_document_id: Optional[str] = document["id"] if "id" in document else None
 
     # Get the document's schema class name so that we can interpret its fields accordingly.
     source_class_name = derive_schema_class_name_from_document(schema_view, document)
@@ -192,6 +192,15 @@ def scan_outgoing_references(
                                 client_session=client_session,
                             )
                         )
+
+                    # Handle the case where the source document does not have an `id`.
+                    #
+                    # Note: As a reminder, according to the NMDC Schema (as of version v11.7.0), documents in the
+                    #       `functional_annotation_agg` collection do not have an `id` field.
+                    #       Reference: https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/
+                    #
+                    if not isinstance(source_document_id, str):
+                        source_document_id = ""
 
                     # Instantiate a `Violation` containing information about this referential integrity violation.
                     violation = Violation(

--- a/tests/schemas/database_with_class_uri.yaml
+++ b/tests/schemas/database_with_class_uri.yaml
@@ -1,0 +1,40 @@
+id: my-schema
+name: MySchema
+
+classes:
+  Database:
+    class_uri: refscan:Database
+    slots:
+      - company_set
+      - employee_set
+  Company:
+    class_uri: refscan:Company
+    slots:
+      - shareholders  # could have been named `has_shared_owned_by`
+      - type
+  Employee:
+    class_uri: refscan:Employee
+    slots:
+      - works_for
+      - managed_by
+      - type
+
+slots:
+  company_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Company
+  employee_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Employee
+  works_for:
+    range: Company
+  shareholders:
+    range: Employee
+    multivalued: true
+  managed_by:
+    range: Employee
+  type:
+    range: string
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -73,7 +73,7 @@ def test_get_collection_name_to_class_names_map():
     schema_view = linkml_runtime.SchemaView(schema="tests/schemas/database_class_with_polymorphic_collections.yaml")
     assert isinstance(schema_view, linkml_runtime.SchemaView)
 
-    collection_name_to_class_names = get_collection_name_to_class_names_map(schema_view)
+    collection_name_to_class_names = get_collection_name_to_class_names_map(schema_view=schema_view)
     assert len(collection_name_to_class_names) == 3
     assert collection_name_to_class_names["biosample_set"] == ["Biosample"]
     assert collection_name_to_class_names["study_set"] == ["Study"]
@@ -115,12 +115,7 @@ def test_get_names_of_classes_in_effective_range_of_slot():
 def test_identify_references():
     schema_view = linkml_runtime.SchemaView(schema="tests/schemas/database_with_references.yaml")
 
-    collection_name_to_class_names = {}
-    for collection_name in get_collection_names_from_schema(schema_view):
-        collection_name_to_class_names[collection_name] = get_names_of_classes_eligible_for_collection(
-            schema_view=schema_view,
-            collection_name=collection_name,
-        )
+    collection_name_to_class_names = get_collection_name_to_class_names_map(schema_view=schema_view)
 
     actual_references = identify_references(schema_view, collection_name_to_class_names)
     assert len(actual_references) == 3

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,151 @@
+import linkml_runtime
+import mongomock
+import pytest
+
+from refscan.lib.Finder import Finder
+from refscan.lib.helpers import get_collection_name_to_class_names_map, identify_references
+from refscan.scanner import (
+    identify_referring_documents,
+    scan_outgoing_references,
+)
+
+
+@pytest.fixture()
+def schema_view():
+    sv = linkml_runtime.SchemaView(schema="tests/schemas/database_with_class_uri.yaml")
+    assert isinstance(sv, linkml_runtime.SchemaView)
+    return sv
+
+
+@pytest.fixture()
+def seeded_db():
+    r"""Returns a (mock) database that has been seeded with interrelated, schema-compliant documents."""
+
+    db = mongomock.MongoClient().db
+
+    # Seed the database with interrelated, schema-compliant data.
+    db["company_set"].insert_many(
+        [
+            {"id": "c-0", "type": "refscan:Company"},
+            {"id": "c-1", "type": "refscan:Company"},
+            {"id": "c-2", "shareholders": ["e-1", "e-3"], "type": "refscan:Company"},
+        ]
+    )
+    db["employee_set"].insert_many(
+        [
+            {"id": "e-1", "works_for": "c-1", "type": "refscan:Employee"},
+            {"id": "e-2", "works_for": "c-2", "type": "refscan:Employee"},
+            {"id": "e-3", "works_for": "c-2", "type": "refscan:Employee"},
+        ]
+    )
+
+    return db
+
+
+def test_identify_referring_documents(schema_view, seeded_db):
+    # Initialize other dependencies for the test (besides the `SchemaView`).
+    finder = Finder(database=seeded_db)
+    collection_name_to_class_names = get_collection_name_to_class_names_map(schema_view=schema_view)
+    references = identify_references(schema_view, collection_name_to_class_names)
+
+    # Case 1: A company that has 0 referring documents.
+    referring_document_descriptors = identify_referring_documents(
+        document={"id": "c-0", "type": "refscan:Company"},
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(referring_document_descriptors) == 0
+
+    # Case 2: A company that has 1 referring documents.
+    referring_document_descriptors = identify_referring_documents(
+        document={"id": "c-1", "type": "refscan:Company"},
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(referring_document_descriptors) == 1
+    assert referring_document_descriptors[0]["source_document_id"] == "e-1"
+    assert referring_document_descriptors[0]["source_collection_name"] == "employee_set"
+    assert referring_document_descriptors[0]["source_class_name"] == "Employee"
+
+    # Case 3: A company that has 2 referring documents.
+    referring_document_descriptors = identify_referring_documents(
+        document={"id": "c-2", "type": "refscan:Company"},
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(referring_document_descriptors) == 2
+    assert set(d["source_collection_name"] for d in referring_document_descriptors) == {"employee_set"}
+    assert set(d["source_class_name"] for d in referring_document_descriptors) == {"Employee"}
+    assert set(d["source_document_id"] for d in referring_document_descriptors) == {"e-2", "e-3"}
+
+
+def test_scan_outgoing_references(schema_view, seeded_db):
+    # Initialize other dependencies for the test (besides the `SchemaView`).
+    finder = Finder(database=seeded_db)
+    collection_name_to_class_names = get_collection_name_to_class_names_map(schema_view=schema_view)
+    references = identify_references(schema_view, collection_name_to_class_names)
+
+    # Case 1: A company that has 0 outgoing references.
+    violations = scan_outgoing_references(
+        document={"_id": None, "id": "c-99", "type": "refscan:Company"},
+        source_collection_name="company_set",
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(violations) == 0
+
+    # Case 2: A company that has 1 intact outgoing reference.
+    violations = scan_outgoing_references(
+        document={"_id": None, "id": "c-99", "shareholders": ["e-1"], "type": "refscan:Company"},
+        source_collection_name="company_set",
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(violations) == 0
+
+    # Case 3: A company that has 2 intact outgoing references.
+    violations = scan_outgoing_references(
+        document={"_id": None, "id": "c-99", "shareholders": ["e-1", "e-2"], "type": "refscan:Company"},
+        source_collection_name="company_set",
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(violations) == 0
+
+    # Case 4: A company that has 1 invalid reference (out of 2).
+    violations = scan_outgoing_references(
+        document={"_id": None, "id": "c-99", "shareholders": ["e-1", "e-99"], "type": "refscan:Company"},
+        source_collection_name="company_set",
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(violations) == 1
+    assert violations[0].source_document_id == "c-99"
+    assert violations[0].source_collection_name == "company_set"
+    assert violations[0].source_class_name == "Company"
+    assert violations[0].source_field_name == "shareholders"
+    assert violations[0].target_id == "e-99"
+    assert violations[0].name_of_collection_containing_target is None
+
+    # Case 5: A company that has 2 invalid references (out of 2).
+    violations = scan_outgoing_references(
+        document={"_id": None, "id": "c-99", "shareholders": ["e-98", "e-99"], "type": "refscan:Company"},
+        source_collection_name="company_set",
+        schema_view=schema_view,
+        references=references,
+        finder=finder,
+    )
+    assert len(violations) == 2
+    assert set(v.target_id for v in violations) == {"e-98", "e-99"}
+    assert set(v.source_field_name for v in violations) == {"shareholders"}
+    assert set(v.source_document_id for v in violations) == {"c-99"}
+    assert set(v.source_collection_name for v in violations) == {"company_set"}
+    assert set(v.source_class_name for v in violations) == {"Company"}
+    assert set(v.name_of_collection_containing_target for v in violations) == {None}


### PR DESCRIPTION
On this branch, I updated the `scan_outgoing_references` function so it would not require the caller to provide so many pieces of information. Now, it obtains more information (specifically, `reference_field_names_by_source_class_name` and `collection_names`) by itself.

Also on this branch, I introduced `mypy` (the static type checker) as a development dependency. Then, I ran it and addressed several of the issues that it found. Most, if not all, of the remaining issues have to do with things being `str`s instead of `Path`s (or vice versa). Here they are:

```console
$ poetry run mypy
refscan/cli/graph.py:36: error: Incompatible default for argument "graph_file_path" (default has type "str", argument has type "Optional[Path]")  [assignment]
refscan/cli/graph.py:76: error: Argument 1 to "open" has incompatible type "Optional[Path]"; expected "Union[int, Union[str, bytes, PathLike[str], PathLike[bytes]]]"  [arg-type]
refscan/cli/scan.py:83: error: Incompatible default for argument "reference_report_file_path" (default has type "str", argument has type "Optional[Path]")  [assignment]
refscan/cli/scan.py:94: error: Incompatible default for argument "violation_report_file_path" (default has type "str", argument has type "Optional[Path]")  [assignment]
refscan/cli/scan.py:151: error: Argument "file_path" to "dump_to_tsv_file" of "ReferenceList" has incompatible type "Optional[Path]"; expected "Union[str, Path]"  [arg-type]
refscan/cli/scan.py:210: error: Argument "file_path" to "dump_to_tsv_file" of "ViolationList" has incompatible type "Optional[Path]"; expected "Union[str, Path]"  [arg-type]
Found 6 errors in 2 files (checked 22 source files)
```

Also on this branch, I introduced the first tests that target high-level functions exposed by the `scanner.py` module; namely, the `identify_referring_documents` and `scan_outgoing_references` functions.

Fixes #50 and https://github.com/microbiomedata/refscan/issues/52