### PR TITLE
Refrain from accessing `id` field of documents that lack it

### DIFF
--- a/refscan/scanner.py
+++ b/refscan/scanner.py
@@ -93,6 +93,17 @@ def identify_referring_documents(
 
         # For each referring document, store a descriptor of it.
         for referring_document in referring_documents:
+
+            # Handle the case where the source document does not have an `id`.
+            #
+            # Note: As a reminder, according to the NMDC Schema (as of version v11.8.0), documents in the
+            #       `functional_annotation_agg` collection do not have an `id` field.
+            #       Reference: https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/
+            #
+            source_document_id = referring_document.get("id", None)
+            if not isinstance(source_document_id, str):
+                source_document_id = ""
+
             source_class_name = translate_class_uri_into_schema_class_name(
                 schema_view=schema_view,
                 class_uri=referring_document["type"],
@@ -101,7 +112,7 @@ def identify_referring_documents(
                 source_collection_name=collection_name,
                 source_class_name=source_class_name,
                 source_document_object_id=referring_document["_id"],
-                source_document_id=referring_document["id"],
+                source_document_id=source_document_id,
             )
             referring_document_descriptors.append(document_descriptor)
 
@@ -195,7 +206,7 @@ def scan_outgoing_references(
 
                     # Handle the case where the source document does not have an `id`.
                     #
-                    # Note: As a reminder, according to the NMDC Schema (as of version v11.7.0), documents in the
+                    # Note: As a reminder, according to the NMDC Schema (as of version v11.8.0), documents in the
                     #       `functional_annotation_agg` collection do not have an `id` field.
                     #       Reference: https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/
                     #

--- a/refscan/scanner.py
+++ b/refscan/scanner.py
@@ -52,6 +52,10 @@ def identify_referring_documents(
     # Initialize a list of descriptors of documents that reference the specified document.
     referring_document_descriptors = []
 
+    # If the specified document does not have an `id` field, we know it cannot be referenced.
+    if "id" not in document:
+        return referring_document_descriptors
+
     # Get the specified document's `id` and derive its schema class name.
     document_id = document["id"]
     document_class_name = derive_schema_class_name_from_document(schema_view, document)

--- a/tests/schemas/database_with_class_uri.yaml
+++ b/tests/schemas/database_with_class_uri.yaml
@@ -7,16 +7,26 @@ classes:
     slots:
       - company_set
       - employee_set
+      - testimonial_set
   Company:
     class_uri: refscan:Company
     slots:
+      - id
       - shareholders  # could have been named `has_shared_owned_by`
       - type
   Employee:
     class_uri: refscan:Employee
     slots:
+      - id
       - works_for
       - managed_by
+      - type
+  Testimonial:
+    class_uri: refscan:Testimonial
+    slots:
+      # Note: We intentionally left the `id` slot off of this class.
+      - company
+      - message
       - type
 
 slots:
@@ -28,6 +38,10 @@ slots:
     inlined_as_list: true
     multivalued: true
     range: Employee
+  testimonial_set:
+    inlined_as_list: true
+    multivalued: true
+    range: Testimonial
   works_for:
     range: Company
   shareholders:
@@ -35,6 +49,12 @@ slots:
     multivalued: true
   managed_by:
     range: Employee
+  id:
+    range: string
   type:
     range: string
+  message:
+    range: string
+  company:
+    range: Company
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -86,7 +86,10 @@ def test_identify_referring_documents(schema_view, seeded_db):
         finder=finder,
     )
     assert len(referring_document_descriptors) == 4
-    assert set(d["source_collection_name"] for d in referring_document_descriptors) == {"employee_set", "testimonial_set"}
+    assert set(d["source_collection_name"] for d in referring_document_descriptors) == {
+        "employee_set",
+        "testimonial_set",
+    }
     assert set(d["source_class_name"] for d in referring_document_descriptors) == {"Employee", "Testimonial"}
     assert set(d["source_document_id"] for d in referring_document_descriptors) == {"e-2", "e-3", ""}
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -43,8 +43,8 @@ def seeded_db():
     #       and we want to ensure that case is handled correctly.
     db["testimonial_set"].insert_many(
         [
+            {"company": "c-2", "message": "Good company!", "type": "refscan:Testimonial"},
             {"company": "c-2", "message": "Great company!", "type": "refscan:Testimonial"},
-            {"company": "c-2", "message": "Excellent service!", "type": "refscan:Testimonial"},
         ]
     )
 
@@ -78,17 +78,17 @@ def test_identify_referring_documents(schema_view, seeded_db):
     assert referring_document_descriptors[0]["source_collection_name"] == "employee_set"
     assert referring_document_descriptors[0]["source_class_name"] == "Employee"
 
-    # Case 3: A company that has 2 referring documents.
+    # Case 3: A company that has 4 referring documents.
     referring_document_descriptors = identify_referring_documents(
         document={"id": "c-2", "type": "refscan:Company"},
         schema_view=schema_view,
         references=references,
         finder=finder,
     )
-    assert len(referring_document_descriptors) == 2
-    assert set(d["source_collection_name"] for d in referring_document_descriptors) == {"employee_set"}
-    assert set(d["source_class_name"] for d in referring_document_descriptors) == {"Employee"}
-    assert set(d["source_document_id"] for d in referring_document_descriptors) == {"e-2", "e-3"}
+    assert len(referring_document_descriptors) == 4
+    assert set(d["source_collection_name"] for d in referring_document_descriptors) == {"employee_set", "testimonial_set"}
+    assert set(d["source_class_name"] for d in referring_document_descriptors) == {"Employee", "Testimonial"}
+    assert set(d["source_document_id"] for d in referring_document_descriptors) == {"e-2", "e-3", ""}
 
 
 def test_scan_outgoing_references(schema_view, seeded_db):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -38,6 +38,15 @@ def seeded_db():
             {"id": "e-3", "works_for": "c-2", "type": "refscan:Employee"},
         ]
     )
+    # Note: These documents lack an `id` field. There is a collection in the real NMDC schema
+    #       whose documents lack an `id` field (i.e. the `functional_annotation_agg` collection),
+    #       and we want to ensure that case is handled correctly.
+    db["testimonial_set"].insert_many(
+        [
+            {"company": "c-2", "message": "Great company!", "type": "refscan:Testimonial"},
+            {"company": "c-2", "message": "Excellent service!", "type": "refscan:Testimonial"},
+        ]
+    )
 
     return db
 


### PR DESCRIPTION
On this branch, I updated the `identify_referring_documents` function so that it no longer accesses the `id` field of documents that lack it. I also updated the tests targeting that function, so that they include a case where a referring document lacks an `id` field.