### PR TITLE
Update GHA workflow to explicitly use release tag name

### DIFF
--- a/.github/workflows/build-and-publish-package-to-pypi.yml
+++ b/.github/workflows/build-and-publish-package-to-pypi.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies  # Docs: https://python-poetry.org/docs/cli/#install
         run: poetry install --no-interaction
       - name: Update package version  # Docs: https://python-poetry.org/docs/cli/#version
-        run: poetry version ${{ github.ref_name }}
+        run: poetry version ${{ github.event.release.tag_name }}
       - name: Build package  # Docs: https://python-poetry.org/docs/cli/#build
         run: poetry build
       - name: Save the built package for publishing later  # Docs: https://github.com/actions/upload-artifact


### PR DESCRIPTION
Usually, `${{ github.ref_name }}` gives us the tag name... 

Example: https://github.com/microbiomedata/refscan/actions/runs/15429437135/job/43424155471

...but not always.

Example: https://github.com/microbiomedata/refscan/actions/runs/16277454729/job/45959715562

On this branch, I have switched to referencing the release tag name explicitly.