### PR TITLE
Simplify function used to get package version identifier

### DIFF
--- a/refscan/__init__.py
+++ b/refscan/__init__.py
@@ -1,18 +1,23 @@
-from importlib.metadata import metadata, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional
 
 
-def get_package_metadata(key: str) -> str:
+def get_package_version(package_name: str) -> Optional[str]:
     r"""
-    Returns metadata about the installed package.
+    Returns the version identifier (e.g., "1.2.3") of the package having the specified name.
 
-    References:
-    - https://docs.python.org/3/library/importlib.metadata.html#distribution-metadata
-    - https://github.com/python-poetry/poetry/issues/273#issuecomment-570999678
+    Args:
+        package_name: The name of the package
+
+    Returns:
+        The version identifier of the package, or `None` if package not found
     """
-    metadata_value = ""
     try:
-        package_metadata = metadata("refscan")
-        metadata_value = package_metadata.get(key, "")
+        return version(package_name)
     except PackageNotFoundError:
-        pass
-    return metadata_value
+        return None
+
+
+# Make an `import`-able variable whose value is the version identifier of this package.
+app_name = "refscan"
+app_version = get_package_version(app_name)

--- a/refscan/cli/scan.py
+++ b/refscan/cli/scan.py
@@ -16,9 +16,7 @@ from refscan.lib.helpers import (
 )
 from refscan.lib.ViolationList import ViolationList
 from refscan.scanner import scan as refscan_scan
-from refscan import get_package_metadata
-
-app_version = get_package_metadata("Version")
+from refscan import app_version
 
 
 def scan(

--- a/refscan/cli/version.py
+++ b/refscan/cli/version.py
@@ -1,9 +1,7 @@
 import typer
 
 from refscan.lib.constants import console
-from refscan import get_package_metadata
-
-app_version = get_package_metadata("Version")
+from refscan import app_version
 
 
 def version() -> None:

--- a/refscan/grapher.py
+++ b/refscan/grapher.py
@@ -6,7 +6,7 @@ from importlib import resources
 
 import linkml_runtime
 
-from refscan import get_package_metadata
+from refscan import app_version
 from refscan.lib.constants import console
 from refscan.lib.helpers import (
     get_collection_name_to_class_names_map,
@@ -161,7 +161,7 @@ def graph(
     graph_data_json_base64_str = encode_json_value_as_base64_str(elements)
     graph_metadata_json_base64_str = encode_json_value_as_base64_str(
         dict(
-            app_version=get_package_metadata("Version"),
+            app_version=app_version,
             schema_version=schema_view.schema.version,
             subject_singular="class" if subject == Subject.class_ else "collection",
             subject_plural="classes" if subject == Subject.class_ else "collections",


### PR DESCRIPTION
On this branch, I simplified the code related to determining the version of `refscan` that is being used.

Fixes #61 