### PR TITLE
Allow package to be installed in environments running newer Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,7 @@ name = "refscan"
 version = "0.0.0"
 description = "Command-line program that scans the NMDC MongoDB database for referential integrity violations"
 authors = []
-# Note: We constrain the Python version to 3.9.* because we know that `nmdc-schema` has a GitHub Actions
-#       workflow that explicitly installs Python 3.9 and then installs this package.
-#       Reference: https://github.com/microbiomedata/nmdc-schema/blob/127c2438ceb1560438cb29a68f623c752d2ea141/.github/workflows/deploy-docs.yaml#L18
-requires-python = ">= 3.9, < 3.10"
+requires-python = ">= 3.9, < 4.0"
 readme = "README.md"
 keywords = [
     "mongodb",


### PR DESCRIPTION
On this branch, I increased the upper limit of Python versions with which this package advertises compatibility. Now, it can be used in environments running Python versions anywhere within 3.9 <= v < 4 (as opposed to only 3.9 == v).